### PR TITLE
Update Toyota Avalon generations: Added Wikipedia reference and standardized README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Toyota Avalon
 
+This repository contains signal set configurations for the Toyota Avalon, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Toyota Avalon.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Toyota_Avalon"
+
 generations:
   - name: "First Generation (XX10)"
     start_year: 1994


### PR DESCRIPTION
- Added references array with Wikipedia article URL to generations.yaml
- Updated README.md with standard template for vehicle documentation
- Verified all 5 generation entries match Wikipedia production dates:
  * Gen 1 (1994-1999): XX10 platform with 3.0L V6
  * Gen 2 (2000-2004): XX20 platform with 3.0L V6
  * Gen 3 (2005-2012): XX30 platform with 3.5L V6
  * Gen 4 (2013-2018): XX40 platform with hybrid option
  * Gen 5 (2019-2022): TNGA platform, discontinued in US after 2022
